### PR TITLE
Default Connection and Column List

### DIFF
--- a/sgbd/pgsql.sqlexec
+++ b/sgbd/pgsql.sqlexec
@@ -6,37 +6,42 @@
         "queries": {
             "desc" : {
                 "query": "SELECT  '| ' || CASE WHEN n.nspname = current_schema() THEN quote_ident(c.relname) ELSE quote_ident(n.nspname)||'.'||quote_ident(c.relname) END ||' |' AS tblname FROM pg_catalog.pg_class AS c INNER JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace WHERE relkind in ('r','v') AND n.nspname NOT IN ('pg_catalog', 'pg_toast', 'information_schema') ORDER BY n.nspname = current_schema() DESC, pg_catalog.pg_table_is_visible(c.oid) DESC, n.nspname, c.relname",
-                "options": ["-t"],
+                "options": ["-t", "-P null=\"<NULL>\""],
                 "format" : "|%s|"
             },
             "desc table": {
                 "query": "\\d+ %s",
-                "options": [],
+                "options": ["-P null=\"<NULL>\""],
                 "format" : "|%s|"
             },
             "func list" : {
                 "query": "SELECT '| ' || proname || ' |' AS funcname FROM pg_catalog.pg_proc AS c INNER JOIN pg_catalog.pg_namespace AS n ON n.oid = c.pronamespace ORDER BY proname",
-                "options": ["-t"],
+                "options": ["-t", "-P null=\"<NULL>\""],
                 "format": "|%s|"
             },
             "desc func" : {
                 "query": "select pg_get_functiondef(oid) from pg_proc where proname = '%s';",
-                "options": [],
+                "options": ["-P null=\"<NULL>\""],
                 "format": "|%s|"
             },
             "show records": {
                 "query": "select * from %s limit 100",
-                "options": [],
+                "options": ["-P null=\"<NULL>\""],
                 "format" : "|%s|"
             },
             "show recent records": {
                 "query": "select * from %s order by %sid DESC limit 100",
-                "options": [],
+                "options": ["-P null=\"<NULL>\""],
                 "format" : "|%s|"
             },
-            "column": {
-                "query": "SELECT * FROM INFORMATION_SCHEMA.columns WHERE column_name ILIKE '%s';",
-                "options": [],
+            "column list": {
+                "query": "SELECT DISTINCT column_name FROM INFORMATION_SCHEMA.columns ORDER BY column_name ASC;",
+                "options": ["-t", "-P null=\"<NULL>\""],
+                "format" : "|%s|"
+            },
+            "desc column": {
+                "query": "SELECT * FROM INFORMATION_SCHEMA.columns WHERE column_name = '%s';",
+                "options": ["-P null=\"<NULL>\""],
                 "format" : "|%s|"
             }
         }


### PR DESCRIPTION
Allows a connection to be set as the default, which will be connected
automatically on open.
Instead of using an input panel to search for columns, they're shown in
a quick panel. This allows the user to leverage sublime's fuzzy matching
functionality.
