### PR TITLE
Non-blocking Queries

### DIFF
--- a/SQLExec.sublime-settings
+++ b/SQLExec.sublime-settings
@@ -1,11 +1,12 @@
 {
-    "sql_exec.debug": false,
-    "sql_exec.commands": {
+    "commands": {
         "mysql"  : "mysql",
         "pgsql"  : "psql",
         "oracle" : "sqlplus",
         "vertica": "vsql",
     },
     "connections": {
-    }
+    },
+    "query_timeout": 0,
+    "show_result_on_window": false
 }

--- a/sgbd/mysql.sqlexec
+++ b/sgbd/mysql.sqlexec
@@ -2,7 +2,7 @@
     "sql_exec": {
         "options": ["-f", "--table"],
         "before": [],
-        "args": "-h{options.host} -P{options.port} -u\"{options.username}\" -p\"{options.password}\" -D\"{options.database}\"",
+        "args": "-h{host} -P{port} -u\"{username}\" -p\"{password}\" -D\"{database}\"",
         "queries": {
             "desc" : {
                 "query": "show tables",

--- a/sgbd/oracle.sqlexec
+++ b/sgbd/oracle.sqlexec
@@ -7,7 +7,7 @@
             "set linesize 500",
             "set tab off"
         ],
-        "args": "{options.username}/{options.password}@\"(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST={options.host})(PORT={options.port})))(CONNECT_DATA=(SERVICE_NAME={options.service})))\"",
+        "args": "{username}/{password}@\"(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST={host})(PORT={port})))(CONNECT_DATA=(SERVICE_NAME={service})))\"",
         "queries": {
             "desc" : {
                 "query": "select CONCAT(CONCAT('| ', table_name), ' |') as tables from user_tables;",

--- a/sgbd/pgsql.sqlexec
+++ b/sgbd/pgsql.sqlexec
@@ -2,7 +2,7 @@
     "sql_exec": {
         "options": [],
         "before": [],
-        "args": "-h {options.host} -p {options.port} -U \"{options.username}\" -d \"{options.database}\"",
+        "args": "-h {host} -p {port} -U \"{username}\" -d \"{database}\"",
         "queries": {
             "desc" : {
                 "query": "SELECT  '| ' || CASE WHEN n.nspname = current_schema() THEN quote_ident(c.relname) ELSE quote_ident(n.nspname)||'.'||quote_ident(c.relname) END ||' |' AS tblname FROM pg_catalog.pg_class AS c INNER JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace WHERE relkind in ('r','v') AND n.nspname NOT IN ('pg_catalog', 'pg_toast', 'information_schema') ORDER BY n.nspname = current_schema() DESC, pg_catalog.pg_table_is_visible(c.oid) DESC, n.nspname, c.relname",

--- a/sgbd/vertica.sqlexec
+++ b/sgbd/vertica.sqlexec
@@ -2,7 +2,7 @@
     "sql_exec": {
         "options": [],
         "before" : [],
-        "args": "-h {options.host} -p {options.port} -U \"{options.username}\" -w \"{options.password}\" -d \"{options.database}\"",
+        "args": "-h {host} -p {port} -U \"{username}\" -w \"{password}\" -d \"{database}\"",
         "queries": {
             "desc" : {
                 "query": "\\dt",


### PR DESCRIPTION
Refactored most everything to make all queries run in a background thread. Now long queries won't lock up the entire UI for the duration.

Adding query timing to see just how long a query ran.

Removed tempfiles that would be created on every query by instead pipiing the query directly.

Fixed issues with duplicate entries in the quick select panel.

Fixed issue with the history getting out of order.

Removed seperate error output, opting to instead just combine everything into a single pane.